### PR TITLE
[security,selinux] Install aos var dir in the recipe

### DIFF
--- a/recipes-security/selinux/selinux-autorelabel_%.bbappend
+++ b/recipes-security/selinux/selinux-autorelabel_%.bbappend
@@ -5,6 +5,8 @@ SRC_URI += " \
 "
 
 do_install:append() {
+    install -d ${D}${aos_var_dir}
+
     sed -i -e 's#/.autorelabel#/var/aos/.autorelabel#g' ${D}${bindir}/${SELINUX_SCRIPT_SRC}.sh
 
     if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then


### PR DESCRIPTION
This recipe fails on the yocto scarthgap build with  an error /var/aos folder doesn't exist on the rootfs that's being built.
Looks like this recipe is executed prior to the ones that create this folder.