### PR TITLE
[initramfs] Add force flag to rsync for incremental FOTA update

### DIFF
--- a/recipes-core/initrdscripts/initramfs-framework/aosupdate
+++ b/recipes-core/initrdscripts/initramfs-framework/aosupdate
@@ -198,7 +198,7 @@ do_apply() {
         ;;
 
     incremental)
-        rsync -av -A -X --ignore-times "$IMAGE_MOUNT/" "$ROOTFS_DIR/"
+        rsync -av -A -X --ignore-times --force "$IMAGE_MOUNT/" "$ROOTFS_DIR/"
 
         find "$ROOTFS_DIR/" -type c -exec rm -f {} \;
         ;;


### PR DESCRIPTION
Without this flag we can't copy symlink instead of folder.